### PR TITLE
Value over $1000 will throw an error on older devices

### DIFF
--- a/wgdr.php
+++ b/wgdr.php
@@ -324,7 +324,7 @@ class WGDR{
 		ecomm_totalvalue: <?php 
 				
 			$product = get_product( get_the_ID() );
-			echo $product->get_price();
+			echo str_replace(",","",$product->get_price());
 									
 			?>
 			


### PR DESCRIPTION
Value over $1000 will throw an error on older devices "Uncaught SyntaxError: Unexpected token }" -- comma makes JS expect next property in object. 

Removing , from string fixes error.

e.g. 1,234.56 becomes 1234.56